### PR TITLE
Changed MQTT message to retain

### DIFF
--- a/raspigaragealert/services/mqtt.py
+++ b/raspigaragealert/services/mqtt.py
@@ -25,7 +25,7 @@ class Publisher():
         """
 
         try:
-            publish.single(self.channel, message, hostname=self.server, client_id=self.client_id)
+            publish.single(self.channel, message, retain=True, hostname=self.server, client_id=self.client_id)
             return True
         except:
             print("Server DNS issue.")


### PR DESCRIPTION
Retaining a message is preferred when you want status to be delivered
to clients without status having to change. So if you restart your
Home Assistant you want it to know that the garage door is in state X
without having to push an extra message for no reason.